### PR TITLE
Thermo.out

### DIFF
--- a/thermo/gpumd/data.py
+++ b/thermo/gpumd/data.py
@@ -179,6 +179,71 @@ def __modal_analysis_read(nbins, nsamples, datapath,
 # Data-loading Related
 #########################################
 
+def load_thermo(directory='', filename='thermo.out', orthogonal=False, triclinic=False):
+    """
+    loads data from thermo.out GPUMD output file.
+
+    Args:
+        directory (str):
+            Directory to load 'thermo.out' file from (dir. of simulation)
+
+        filename (str):
+            file to load thermo from
+
+        orthogonal (bool):
+            allows user to set as true if orthogonal,  effects the total number of columns of data to add to
+
+        triclinic (bool):
+            allows user to set as true if triclinic, effects the total number of columns of data to add to
+
+        Returns:
+            'output' dictionary containing the data from thermo.out (ex: temperature, kinetic energy, etc.)
+    """
+    if directory == '':
+        t_path = os.path.join(os.getcwd(), filename)
+    else:
+        t_path = os.path.join(directory, filename)
+
+    # probably a much better way to check for these errors
+    # will data always be float?
+    with open(t_path) as f:
+        lines = f.readlines()
+        for i in range(len(lines)):
+            if lines[i] == float('inf') or lines[i] == float('-inf'):
+                raise ValueError("inf or -inf data point")
+            # if type(lines[i]) != float:
+            #     raise ValueError("invalid data")
+
+    output = dict()
+    # possibly another way to filter problematic data?
+    output['T'] = np.loadtxt(t_path, dtype=float, usecols=0)
+    output['K'] = np.loadtxt(t_path, dtype=float, usecols=1)
+    output['U'] = np.loadtxt(t_path,  dtype=float, usecols=2)
+
+    output['Px'] = np.loadtxt(t_path, dtype=float, usecols=3)
+    output['Py'] = np.loadtxt(t_path, dtype=float, usecols=4)
+    output['Pz'] = np.loadtxt(t_path, dtype=float, usecols=5)
+
+    if orthogonal:
+        output['Lx'] = np.loadtxt(t_path, dtype=float, usecols=6)
+        output['Ly'] = np.loadtxt(t_path, dtype=float, usecols=7)
+        output['Lz'] = np.loadtxt(t_path, dtype=float, usecols=8)
+
+    if triclinic:
+        output['ax'] = np.loadtxt(t_path, dtype=float, usecols=9)
+        output['ay'] = np.loadtxt(t_path, dtype=float, usecols=10)
+        output['az'] = np.loadtxt(t_path, dtype=float, usecols=11)
+
+        output['bx'] = np.loadtxt(t_path, dtype=float, usecols=9)
+        output['by'] = np.loadtxt(t_path, dtype=float, usecols=10)
+        output['bz'] = np.loadtxt(t_path, dtype=float, usecols=11)
+
+        output['cx'] = np.loadtxt(t_path, dtype=float, usecols=12)
+        output['cy'] = np.loadtxt(t_path, dtype=float, usecols=13)
+        output['cz'] = np.loadtxt(t_path, dtype=float, usecols=14)
+
+    return output
+
 
 def load_heatmode(nbins, nsamples, directory=None,
                    inputfile='heatmode.out', directions='xyz',

--- a/thermo/gpumd/data.py
+++ b/thermo/gpumd/data.py
@@ -179,7 +179,7 @@ def __modal_analysis_read(nbins, nsamples, datapath,
 # Data-loading Related
 #########################################
 
-def load_thermo(directory='', filename='thermo.out', orthogonal=False, triclinic=False):
+def load_thermo(directory='', filename='thermo.out', triclinic=False):
     """
     loads data from thermo.out GPUMD output file.
 
@@ -190,11 +190,9 @@ def load_thermo(directory='', filename='thermo.out', orthogonal=False, triclinic
         filename (str):
             file to load thermo from
 
-        orthogonal (bool):
-            allows user to set as true if orthogonal,  effects the total number of columns of data to add to
-
         triclinic (bool):
-            allows user to set as true if triclinic, effects the total number of columns of data to add to
+            allows user to set as true if triclinic, effects the total number of columns of data to add to.
+            if triclinic is false, then orthogonal by default.
 
         Returns:
             'output' dictionary containing the data from thermo.out (ex: temperature, kinetic energy, etc.)
@@ -204,43 +202,37 @@ def load_thermo(directory='', filename='thermo.out', orthogonal=False, triclinic
     else:
         t_path = os.path.join(directory, filename)
 
-    # probably a much better way to check for these errors
-    # will data always be float?
-    with open(t_path) as f:
-        lines = f.readlines()
-        for i in range(len(lines)):
-            if lines[i] == float('inf') or lines[i] == float('-inf'):
-                raise ValueError("inf or -inf data point")
-            # if type(lines[i]) != float:
-            #     raise ValueError("invalid data")
-
     output = dict()
-    # possibly another way to filter problematic data?
-    output['T'] = np.loadtxt(t_path, dtype=float, usecols=0)
-    output['K'] = np.loadtxt(t_path, dtype=float, usecols=1)
-    output['U'] = np.loadtxt(t_path,  dtype=float, usecols=2)
+    lst = []
+    with open(t_path) as f:
+        for line in f:
+            lst.append([float(num) for num in line.split()])
+    output['T'] = [num[0] for num in lst]
+    output['K'] = [num[1] for num in lst]
+    output['U'] = [num[2] for num in lst]
 
-    output['Px'] = np.loadtxt(t_path, dtype=float, usecols=3)
-    output['Py'] = np.loadtxt(t_path, dtype=float, usecols=4)
-    output['Pz'] = np.loadtxt(t_path, dtype=float, usecols=5)
+    output['Px'] = [num[3] for num in lst]
+    output['Py'] = [num[4] for num in lst]
+    output['Pz'] = [num[5] for num in lst]
 
-    if orthogonal:
-        output['Lx'] = np.loadtxt(t_path, dtype=float, usecols=6)
-        output['Ly'] = np.loadtxt(t_path, dtype=float, usecols=7)
-        output['Lz'] = np.loadtxt(t_path, dtype=float, usecols=8)
+    # orthogonal
+    if not triclinic:
+        output['Lx'] = [num[6] for num in lst]
+        output['Ly'] = [num[7] for num in lst]
+        output['Lz'] = [num[8] for num in lst]
 
     if triclinic:
-        output['ax'] = np.loadtxt(t_path, dtype=float, usecols=9)
-        output['ay'] = np.loadtxt(t_path, dtype=float, usecols=10)
-        output['az'] = np.loadtxt(t_path, dtype=float, usecols=11)
+        output['ax'] = [num[6] for num in lst]
+        output['ay'] = [num[7] for num in lst]
+        output['az'] = [num[8] for num in lst]
 
-        output['bx'] = np.loadtxt(t_path, dtype=float, usecols=9)
-        output['by'] = np.loadtxt(t_path, dtype=float, usecols=10)
-        output['bz'] = np.loadtxt(t_path, dtype=float, usecols=11)
+        output['bx'] = [num[9] for num in lst]
+        output['by'] = [num[10] for num in lst]
+        output['bz'] = [num[11] for num in lst]
 
-        output['cx'] = np.loadtxt(t_path, dtype=float, usecols=12)
-        output['cy'] = np.loadtxt(t_path, dtype=float, usecols=13)
-        output['cz'] = np.loadtxt(t_path, dtype=float, usecols=14)
+        output['cx'] = [num[12] for num in lst]
+        output['cy'] = [num[13] for num in lst]
+        output['cz'] = [num[14] for num in lst]
 
     return output
 

--- a/thermo/gpumd/data.py
+++ b/thermo/gpumd/data.py
@@ -202,43 +202,22 @@ def load_thermo(directory=None, filename='thermo.out',triclinic=False):
     else:
         t_path = os.path.join(directory, filename)
 
-    output = {'T': list(), 'K': list(), 'U': list(), 'Px': list(), 'Py': list(), 'Pz': list()}
-    orthogonal = {'Lx': list(), 'Ly': list(), 'Lz': list()}
-    tri = {'ax': list(), 'ay': list(), 'az': list(), 'bx': list(), 'by': list(), 'bz': list(), 'cx': list(),
-                 'cy': list(), 'cz': list()}
+    output = {'T': [], 'K': [], 'U': [], 'Px': [], 'Py': [], 'Pz': []}
+
+    # orthogonal
+    if not triclinic:
+        output.update({'Lx': [], 'Ly': [], 'Lz': []})
+
+    # triclinic
+    else:
+        output.update({'ax': [], 'ay': [], 'az': [], 'bx': [], 'by': [], 'bz': [], 'cx': [], 'cy': [], 'cz': []})
 
     with open(t_path) as f:
         for line in f:
             data = [float(num) for num in line.split()]
-            output['T'].append(data[0])
-            output['K'].append(data[1])
-            output['U'].append(data[2])
-
-            output['Px'].append(data[3])
-            output['Py'].append(data[4])
-            output['Pz'].append(data[5])
-
-            # orthogonal
-            if not triclinic:
-                orthogonal['Lx'].append(data[6])
-                orthogonal['Ly'].append(data[7])
-                orthogonal['Lz'].append(data[8])
-                output.update(orthogonal)
-
-            if triclinic:
-                tri['ax'].append(data[6])
-                tri['ay'].append(data[7])
-                tri['az'].append(data[8])
-
-                tri['bx'].append(data[9])
-                tri['by'].append(data[10])
-                tri['bz'].append(data[11])
-
-                tri['cx'].append(data[12])
-                tri['cy'].append(data[13])
-                tri['cz'].append(data[14])
-                output.update(tri)
-
+            for key in output.keys():
+                index = list(output.keys()).index(key)
+                output[key].append(data[index])
     return output
 
 

--- a/thermo/gpumd/data.py
+++ b/thermo/gpumd/data.py
@@ -179,7 +179,7 @@ def __modal_analysis_read(nbins, nsamples, datapath,
 # Data-loading Related
 #########################################
 
-def load_thermo(directory='', filename='thermo.out', triclinic=False):
+def load_thermo(directory=None, filename='thermo.out',triclinic=False):
     """
     loads data from thermo.out GPUMD output file.
 
@@ -197,42 +197,47 @@ def load_thermo(directory='', filename='thermo.out', triclinic=False):
         Returns:
             'output' dictionary containing the data from thermo.out (ex: temperature, kinetic energy, etc.)
     """
-    if directory == '':
+    if not directory:
         t_path = os.path.join(os.getcwd(), filename)
     else:
         t_path = os.path.join(directory, filename)
 
-    output = dict()
-    lst = []
+    output = {'T': list(), 'K': list(), 'U': list(), 'Px': list(), 'Py': list(), 'Pz': list()}
+    orthogonal = {'Lx': list(), 'Ly': list(), 'Lz': list()}
+    tri = {'ax': list(), 'ay': list(), 'az': list(), 'bx': list(), 'by': list(), 'bz': list(), 'cx': list(),
+                 'cy': list(), 'cz': list()}
+
     with open(t_path) as f:
         for line in f:
-            lst.append([float(num) for num in line.split()])
-    output['T'] = [num[0] for num in lst]
-    output['K'] = [num[1] for num in lst]
-    output['U'] = [num[2] for num in lst]
+            data = [float(num) for num in line.split()]
+            output['T'].append(data[0])
+            output['K'].append(data[1])
+            output['U'].append(data[2])
 
-    output['Px'] = [num[3] for num in lst]
-    output['Py'] = [num[4] for num in lst]
-    output['Pz'] = [num[5] for num in lst]
+            output['Px'].append(data[3])
+            output['Py'].append(data[4])
+            output['Pz'].append(data[5])
 
-    # orthogonal
-    if not triclinic:
-        output['Lx'] = [num[6] for num in lst]
-        output['Ly'] = [num[7] for num in lst]
-        output['Lz'] = [num[8] for num in lst]
+            # orthogonal
+            if not triclinic:
+                orthogonal['Lx'].append(data[6])
+                orthogonal['Ly'].append(data[7])
+                orthogonal['Lz'].append(data[8])
+                output.update(orthogonal)
 
-    if triclinic:
-        output['ax'] = [num[6] for num in lst]
-        output['ay'] = [num[7] for num in lst]
-        output['az'] = [num[8] for num in lst]
+            if triclinic:
+                tri['ax'].append(data[6])
+                tri['ay'].append(data[7])
+                tri['az'].append(data[8])
 
-        output['bx'] = [num[9] for num in lst]
-        output['by'] = [num[10] for num in lst]
-        output['bz'] = [num[11] for num in lst]
+                tri['bx'].append(data[9])
+                tri['by'].append(data[10])
+                tri['bz'].append(data[11])
 
-        output['cx'] = [num[12] for num in lst]
-        output['cy'] = [num[13] for num in lst]
-        output['cz'] = [num[14] for num in lst]
+                tri['cx'].append(data[12])
+                tri['cy'].append(data[13])
+                tri['cz'].append(data[14])
+                output.update(tri)
 
     return output
 


### PR DESCRIPTION
### Purpose:
The thermo.out file contains global thermodynamic quantities. The thermo.out function reads this information to the output dictionary depending on if it's triclinic or orthogonal. 

### Details:
The thermo.out function processes the keys from the thermo.out file to the output dictionary, which contain the following values:

- T: temperature (K) 
- K: kinetic energy of systems (eV) 
- U: potential energy (eV)
- Px: pressure in the x direction (GPa) 
- Py: pressure in the y direction (GPa)
- Pz: pressure in the z direction (GPa) 

 
The code allows the user between an orthogonal or a triclinic simulation box. If orthogonal, the thermo.out code will add the following keys to the output dictionary in addition to the standard ones (units are in angstrom): 

- Lx: box length in the x direction 
- Ly: box length in the y direction
- Lz: box length in the z direction

If triclinic, it will add, “ax”, “ay”, “az”, “bx”, “by”, “bz”, “cx”, “cy”, “cz” to output, which are the components of the triclinic box (in angstrom). 

Once the size and values for output have been determined, the function parses through the columns of the thermo.out file (line by line), and loads the data into its respective key (as a list). The code returns the output dictionary in the end. 


	
